### PR TITLE
Add boost to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Installation
 
 1. Install all required dependencies required by ns-3.
 ```
-# minimal requirements for C++:
+# minimal requirements for C++ and boost:
 apt-get install gcc g++ python
+apt-get install libboost-all-dev
 
 see https://www.nsnam.org/wiki/Installation
 ```


### PR DESCRIPTION
boost/algorithm/string.hpp is included in opengym_interface.cc, but the installation instructions do not mention boost. This commit adds a line to the readme that installs boost, so that ns-3 compilation goes smoothly.