### PR TITLE
Casting Box Datatype

### DIFF
--- a/src/opengym/model/ns3gym/ns3gym/ns3env.py
+++ b/src/opengym/model/ns3gym/ns3gym/ns3env.py
@@ -255,6 +255,7 @@ class Ns3ZmqBridge(object):
                 data = boxContainerPb.floatData
 
             # TODO: reshape using shape info
+            data = np.array(data)
             return data
 
         elif (dataContainerPb.type == pb.Tuple):


### PR DESCRIPTION
I tried to integrate ns3gym with stable-baselines. This error was found when the learning process started. The reason was clear enough.

Problem:
********** Iteration 0 ************
Traceback (most recent call last):
  File "ns3_stable_solve.py", line 101, in <module>
    model.learn(total_timesteps=512)
  File "/home/haidlir/ns3/venv/lib/python3.7/site-packages/stable_baselines/ppo1/pposgd_simple.py", line 238, in learn
    seg = seg_gen.__next__()
  File "/home/haidlir/ns3/venv/lib/python3.7/site-packages/stable_baselines/trpo_mpi/utils.py", line 57, in traj_segment_generator
    action, vpred, states, _ = policy.step(observation.reshape(-1, *observation.shape), states, done)
**AttributeError: 'google.protobuf.pyext._message.RepeatedScalarConta' object has no attribute 'reshape'**

Solution:
I recommend casting the variable to np.array just before the return line as in https://github.com/haidlir/ns3-gym/blob/da37d708afa1214078127c4718f0a95be4627122/src/opengym/model/ns3gym/ns3gym/ns3env.py#L258

Moreover, np.array is everywhere as datatype in ML world. Thanks.