### PR TITLE
Refactored to ns-3.42 version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,15 @@
+# ns3-gym change history
+## 1.1.0 - 2024-09-01 :: by [rogerio-silva](https://github.com/rogerio-silva)
+- Added support for ns-3.42
+    * ‘ns3::TestSuite::UNIT’ is deprecated: Use ‘Type::UNIT’ instead
+    * ‘ns3::TestCase::QUICK’ is deprecated: Use ‘Duration::QUICK’ instead
+    * ‘class ns3::InetSocketAddress’ has no member named ‘SetTos’: Refactored the code by adding a socket and setting the TOS field using the SetIpTos method
+      * Refatored the `linear-mesh` and `linear-mesh-2` examples code in the following way:
+        ```c++
+        Ptr<Socket> socket = Socket::CreateSocket (srcNode, UdpSocketFactory::GetTypeId ());
+        socket->SetIpTos (0x70); // AC_BE
+        # ...
+        source.SetAttribute ("Socket", PointerValue (socket));
+        ```
+## [1.0.0] - 2021-06-01
+- Custom implementation

--- a/NS3-VERSION
+++ b/NS3-VERSION
@@ -1,1 +1,1 @@
-release ns-3.36
+release ns-3.42

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ns3-gym
 ============
+*Updated version of ns3-gym for ns-3 release ns-3.42.
 
 [OpenAI Gym](https://gym.openai.com/) is a toolkit for reinforcement learning (RL) widely used in research. The network simulator [ns-3](https://www.nsnam.org/) is the de-facto standard for academic and industry studies in the areas of networking protocols and communication technologies. ns3-gym is a framework that integrates both OpenAI Gym and ns-3 in order to encourage usage of RL in networking research.
 
@@ -26,7 +27,7 @@ apt-get install pkg-config
 cd ./contrib
 git clone https://github.com/tkn-tub/ns3-gym.git ./opengym
 cd opengym/
-git checkout app-ns-3.36+
+git checkout app-ns-3.42
 ```
 Check [working with cmake](https://www.nsnam.org/docs/manual/html/working-with-cmake.html)
 

--- a/examples/linear-mesh-2/sim.cc
+++ b/examples/linear-mesh-2/sim.cc
@@ -204,12 +204,13 @@ main (int argc, char *argv[])
   Ipv4Address dest_ip_addr = dest_ipv4_int_addr.GetLocal ();
 
   InetSocketAddress destAddress (dest_ip_addr, port);
-  destAddress.SetTos (0x70); //AC_BE
+  Ptr<Socket> socket = Socket::CreateSocket (srcNode, UdpSocketFactory::GetTypeId ());
+  socket->SetIpTos (0x70); // AC_BE
   UdpClientHelper source (destAddress);
   source.SetAttribute ("MaxPackets", UintegerValue (pktPerSec * simulationTime));
   source.SetAttribute ("PacketSize", UintegerValue (payloadSize));
-  Time interPacketInterval = Seconds (1.0/pktPerSec);
-  source.SetAttribute ("Interval", TimeValue (interPacketInterval)); //packets/s
+  source.SetAttribute ("Interval", TimeValue (Seconds (1.0 / pktPerSec))); // packets/s
+  source.SetAttribute ("Socket", PointerValue (socket));
 
   ApplicationContainer sourceApps = source.Install (srcNode);
   sourceApps.Start (Seconds (0.0));

--- a/examples/linear-mesh/sim.cc
+++ b/examples/linear-mesh/sim.cc
@@ -349,12 +349,13 @@ main (int argc, char *argv[])
   Ipv4Address dest_ip_addr = dest_ipv4_int_addr.GetLocal ();
 
   InetSocketAddress destAddress (dest_ip_addr, port);
-  destAddress.SetTos (0x70); //AC_BE
+  Ptr<Socket> socket = Socket::CreateSocket (srcNode, UdpSocketFactory::GetTypeId ());
+  socket->SetIpTos (0x70); // AC_BE
   UdpClientHelper source (destAddress);
   source.SetAttribute ("MaxPackets", UintegerValue (pktPerSec * simulationTime));
   source.SetAttribute ("PacketSize", UintegerValue (payloadSize));
-  Time interPacketInterval = Seconds (1.0/pktPerSec);
-  source.SetAttribute ("Interval", TimeValue (interPacketInterval)); //packets/s
+  source.SetAttribute ("Interval", TimeValue (Seconds (1.0 / pktPerSec))); // packets/s
+  source.SetAttribute ("Socket", PointerValue (socket));
 
   ApplicationContainer sourceApps = source.Install (srcNode);
   sourceApps.Start (Seconds (0.0));

--- a/model/ns3gym/ns3gym/start_sim.py
+++ b/model/ns3gym/ns3gym/start_sim.py
@@ -78,7 +78,9 @@ def start_sim_script(port=5555, sim_seed=0, sim_args={}, debug=False):
 
 	os.chdir(base_ns3_dir)
 
-	ns3_string = ns3_path + ' run "' + sim_script_name
+	# Add '\sim' to the path to run the ns-3 simulation script
+	# ns3_string = ns3_path + ' run "' + sim_script_name
+	ns3_string = ns3_path + ' run "' + sim_script_name + '/sim'
 
 	if port:
 		ns3_string += ' --openGymPort=' + str(port)

--- a/test/opengym-test-suite.cc
+++ b/test/opengym-test-suite.cc
@@ -57,10 +57,10 @@ public:
 };
 
 OpengymTestSuite::OpengymTestSuite ()
-  : TestSuite ("opengym", UNIT)
+  : TestSuite ("opengym",  Type::UNIT)
 {
   // TestDuration for TestCase can be QUICK, EXTENSIVE or TAKES_FOREVER
-  AddTestCase (new OpengymTestCase1, TestCase::QUICK);
+  AddTestCase (new OpengymTestCase1,  Duration::QUICK);
 }
 
 // Do not forget to allocate an instance of this TestSuite


### PR DESCRIPTION
# Update for ns-3.42 Compatibility and Code Refactoring

### Description:

This pull request includes several important updates to ensure compatibility with ns-3.42 and refactors some parts of the code for better functionality and alignment with the new API standards. Below is a summary of the changes:

## Version: 1.1.0 - 2024-09-01

**Author:** [rogerio-silva](https://github.com/rogerio-silva)

### Changes:
1. **Code compatibility with ns-3.42:**
   - Ensured the project builds without errors on ns-3.42.

2. **Refactor of `opengym-test-suite.cc`:**
   - Replaced deprecated usage of `ns3::TestSuite::UNIT` with `Type::UNIT`.
   - Replaced deprecated usage of `ns3::TestCase::QUICK` with `Duration::QUICK`.
   - Refactored to handle the removal of `SetTos` in `ns3::InetSocketAddress`, using a socket and setting the TOS field with `SetIpTos()` instead.

3. **Refactor of `linear-mesh` and `linear-mesh-2` examples:**
   - Added a socket and set the TOS field directly using `SetIpTos()`:
     ```cpp
     Ptr<Socket> socket = Socket::CreateSocket (srcNode, UdpSocketFactory::GetTypeId ());
     socket->SetIpTos (0x70); // AC_BE
     # ...
     source.SetAttribute ("Socket", PointerValue (socket));
     ```

These changes are crucial for keeping the code up-to-date with the latest version of ns-3.